### PR TITLE
Updated "getidle" to also show who owns the PTY

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -122,7 +122,7 @@ ptys=`ls /dev/pts | grep '[[:digit:]]' | sort -g | tr '\n' ' '`
 echo $ptys | tr ' ' '\n' | while read i;do
 	echo -ne "PTY $i has been idle for "
 	idler=`stat -t /dev/pts/$i | awk -F " " '{ print $12 }'`
-	echo -ne "$((`date +%s` - $idler)) seconds.\n"
+	echo -ne "$((`date +%s` - $idler)) seconds and is owned by $(stat -c '%U' /dev/pts/$i).\n"
 done
 }
 


### PR DESCRIPTION
Knowing who owns the PTY is something I found useful for something else I was playing with. Can probably be cleaned up but works.

Example output:
```
PTY 0 has been idle for 1908696 seconds and is owned by root
PTY 1 has been idle for 321 seconds and is owned by somebody
PTY 2 has been idle for 1 seconds and is owned by root
```

I'm going to try also add some way to have it flag which PTY is *us* because that is useful to know.