### PR TITLE
Added check to getidle to flag which PTY is us

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -122,7 +122,7 @@ ptys=`ls /dev/pts | grep '[[:digit:]]' | sort -g | tr '\n' ' '`
 echo $ptys | tr ' ' '\n' | while read i;do
 	echo -ne "PTY $i has been idle for "
 	idler=`stat -t /dev/pts/$i | awk -F " " '{ print $12 }'`
-	echo -ne "$((`date +%s` - $idler)) seconds and is owned by $(stat -c '%U' /dev/pts/$i).\n"
+	echo -ne "$((`date +%s` - $idler)) seconds and is owned by $(stat -c '%U' /dev/pts/$i) $(if [ $our_pty = $i ]; then echo "** this is us **"; fi).\n"
 done
 }
 


### PR DESCRIPTION
Now it flags which PTS is us.

```
PTY 0 has been idle for 1910540 seconds and is owned by root 
PTY 1 has been idle for 5 seconds and is owned by root ** this is us **
PTY 2 has been idle for 245 seconds and is owned by somebody
```