### PR TITLE
Replaced a 4 stage pipeline by a single awk call.

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -325,7 +325,11 @@ touch -r /dev/shm/.q/.l /var/log/wtmp
 }
 
 getrel() {
-cat /etc/*release | grep PRETTY | awk -F "=" '{print $2}' | tr --delete '"'
+  # Prints the OS name from the release file.
+  # arguments: none
+  # output   : print to stdout
+  # method   : Cuts the name from lines like PRETTY_NAME="name".
+  awk -F= 'toupper($1)~/PRETTY/ {gsub(/\"/,"",$2); print $2}' /etc/*release
 }
 
 hangup() {


### PR DESCRIPTION
Replaced a pipeline with four tools cat|grep|awk|tr by a single awk call.
Now cat, grep and tr are not use in this function.
No new tool was included because awk was used before.