### PR TITLE
replaced [[ by POSIX conform [

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -80,7 +80,7 @@ crontab -l > $OUTP/user_crontab.txt 2>/dev/null
 	fi
 	
 	netstat -peanut > $OUTP/netstat.txt
-	if [[ $EUID -eq 0 ]]; then
+	if [ "$EUID" = "0" ]; then
 		getent shadow > $OUTP/shadow.txt
 		find /home/ -name id_rsa > $OUTP/ssh_keys.txt
 		cat /etc/sudoers > $OUTP/sudoers.txt


### PR DESCRIPTION
"if [[ condition ]]" works with bash but is not POSIX, e.g. works not in the dash.
"if [ condition ]" should work with all POSIX shells.
Changed the condition to a string compare because this does not cause an error if the variable is not defined.