### PR TITLE
replaced 4 stage pipeline by a single awk

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -243,9 +243,13 @@ echo -ne "DNS says: "
 }
 
 prochide() {
-ARGS="$@"
-LONGARG==$(ps --no-header -weo cmd | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2-  | tail -n 1)
-bash -c "exec -a \"$LONGARG\" $ARGS"
+  # Execute a program hiden by a long program name.
+  # arguments: program to execute with optional arguments.
+  # methode  : use the longest command line of the current running
+  #            processes as name of the program to start.
+  ARGS="$@"
+  LONGARG=$(ps --no-header -wweo cmd | awk 'length(X)<length {X=$0}; END {print X}')
+  bash -c "exec -a \"$LONGARG\" $ARGS"
 }
 
 getnet() (


### PR DESCRIPTION
Replaced a pipeline with four tools awk|sort|cut|tail by a single awk call.
Now sort, cut and tail are not use in this function.
No new tool was included because awk was used before.

Also the equal sign at front of the program names was remove.
The "LONGARG==$(..." seams to be an bug. Now "LONGARG=$" does not prepend a "=" sign to the process name.

The "ps -w" was extended to "ps -ww" from wide output format to unlimited wide output format.