### PR TITLE
Enable to source o.rc. In this case variable ENV is not defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Orc is a simple post-exploitation written in bash.
 I wrote this because I myself needed a more featureful post-exploitation toolkit for Linux. It's part of a larger bundle of scripts and tools, but I'll add those as I write and re-write them.
 
 It takes the form of an ENV script, so load orc into a shell by running ENV=o.rc sh -i (it does need an interactive shell, I'm afraid)
-You can also source it, but than function getpty does not work.
+You can also source it.
 
 It creates a directory (.q) in /dev/shm, and all of the output of commands etc tend to go in there. It will also auto-delete this directory on exit. HISTFILE is unset, and we use ulimit -c 0 to try and prevent any corefiles showing up.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Orc is a simple post-exploitation written in bash.
 I wrote this because I myself needed a more featureful post-exploitation toolkit for Linux. It's part of a larger bundle of scripts and tools, but I'll add those as I write and re-write them.
 
 It takes the form of an ENV script, so load orc into a shell by running ENV=o.rc sh -i (it does need an interactive shell, I'm afraid)
-You can also source it, but that seems to require a CTRL+C, otherwise it hangs. I should probably investigate that.
+You can also source it, but than function getpty does not work.
 
 It creates a directory (.q) in /dev/shm, and all of the output of commands etc tend to go in there. It will also auto-delete this directory on exit. HISTFILE is unset, and we use ulimit -c 0 to try and prevent any corefiles showing up.
 

--- a/o.rc
+++ b/o.rc
@@ -22,8 +22,16 @@ EOF
 )
 
 alias 'echo'='/bin/echo'
-trap "rm -rf /dev/shm/.q" EXIT TERM INT 
-backup=`cat $ENV`
+trap "rm -rf /dev/shm/.q" EXIT TERM INT
+
+# Creates a copy of this scipt in variable backup
+# Needs a start like "ENV=o.rc sh -i".
+backup=""
+if [ -r "$ENV" ]; then
+  backup=`cat $ENV`
+  # Convert to absolute file name for later use.
+  ENV=$(realpath "$ENV")
+fi
 NHOME=""
 
 getdbus() {
@@ -161,8 +169,12 @@ echo "$finalmem" | perl
 
 getpty() {
 SHELL=$(command -v sh)
-#echo "$backup" > $ENV
-ENV=$ENV script -c sh /dev/null
+#echo "$backup" > "$ENV"
+if [ -r "$ENV" ]; then
+  ENV="$ENV" script -c sh /dev/null
+else
+  echo "ENV not defined. Can not start script."
+fi
 }
 
 keyinstall() {

--- a/o.rc
+++ b/o.rc
@@ -27,7 +27,7 @@ trap "rm -rf /dev/shm/.q" EXIT TERM INT
 # Creates a copy of this scipt in variable backup
 # Should be start like "ENV=o.rc sh -i".
 backup=""
-if [ \( ! -r "$ENV" \) -a -r "$BASH_SOURCE" ]; then
+if [ -r "$BASH_SOURCE" -a ! -r "$ENV" ]; then
   # Script was started in bash via source.
   ENV=$BASH_SOURCE
 fi

--- a/o.rc
+++ b/o.rc
@@ -25,8 +25,12 @@ alias 'echo'='/bin/echo'
 trap "rm -rf /dev/shm/.q" EXIT TERM INT
 
 # Creates a copy of this scipt in variable backup
-# Needs a start like "ENV=o.rc sh -i".
+# Should be start like "ENV=o.rc sh -i".
 backup=""
+if [ \( ! -r "$ENV" \) -a -r "$BASH_SOURCE" ]; then
+  # Script was started in bash via source.
+  ENV=$BASH_SOURCE
+fi
 if [ -r "$ENV" ]; then
   backup=`cat $ENV`
   # Convert to absolute file name for later use.


### PR DESCRIPTION
If the script was used by "source o.rc" the variable ENV was not defined.
The line "backup=\`cat $ENV\`" was expanded to backup=\`cat \`.
Then the reads from the console, not from the script file.
The patch checks if $ENV is a readable file, then loads the script file into variable backup.

If the script was called in the bash by "source o.rc" then the name of the script is in the variable
BASH_SOURCE. In this case ENV will be set inside o.rc to the file name found in BASH_SOURCE.

The variable ENV was also used in the function getpty.
In the function getpty a check is added to.

Typical ENV contains the relative file name of the script.
Then using ENV after chaning the cwd does not work in the getpty function.
Now the filename in ENV is converted into an absolute file name.