### PR TITLE
fixed syntax error message after 'ENV=or.c sh -i' call on Ubuntu 18.04

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -187,7 +187,7 @@ fi
 getsuspect() {
 #ask and ye shall receive
 #this janky, awful shortcut
-bash <(curl https://raw.githubusercontent.com/zMarch/suspect/master/suspect.sh) 
+curl https://raw.githubusercontent.com/zMarch/suspect/master/suspect.sh | bash
 }
 
 keyinstall() {


### PR DESCRIPTION
With Ubuntu 18.04LTS the getsuspect function works if o.rc was read with source command in the bash shell.
But the command "ENV=o.rc sh -i" gives an error message:
sh: 190: Syntax error: "(" unexpected

Ubuntu 18.04 has the link “sh → dash”. The sh command starts the dash shell, not the bash shell.
The changed code works with bash and dash shell on Ubuntu 18.04 LTS.