### PR TITLE
alias ssh now uses the extra options from qssh

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -433,7 +433,7 @@ alias 'listener'='netstat -peanuto'
 alias 'netgrep'='netstat -peanuto | grep'
 alias 'getp'='getent passwd'
 
-alias 'ssh'='ssh -T'
+alias 'ssh'='ssh -T -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
 
 unset HISTFILE


### PR DESCRIPTION
Avoids hostkey checking or logging new hostkeys for forensics reasons