### PR TITLE
Bug fix: remove gawk function systime.

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -134,11 +134,12 @@ getidle() {
   # Arguments : none
   # Globals   : our_pty could contain the number of our PTY
   stat /dev/pts/* -c '%n %X %U' |
-  awk '$1 ~ /\/[[:digit:]]+$/ {
+  awk -v now=$(date +%s) '$1 ~ /\/[[:digit:]]+$/ {
       gsub( /[^[:digit:]]/, "", $1 )
-      list[$1]="PTY " $1 " is " systime()-$2 " seconds idle and owned by " $3
+      list[$1]="PTY " $1 " is " now-$2 " seconds idle and owned by " $3
       if( $1==ENVIRON["our_pty"] ) list[$1]=list[$1] " ** this is us **"}
       END {for(i in list) print list[i]}'
+  # reminder: do not use gawk functions, e.g. systime
 }
 
 srm() {

--- a/o.rc
+++ b/o.rc
@@ -134,8 +134,8 @@ getidle() {
   # Arguments : none
   # Globals   : our_pty could contain the number of our PTY
   stat /dev/pts/* -c '%n %X %U' |
-  awk -v now=$(date +%s) '$1 ~ /\/[[:digit:]]+$/ {
-      gsub( /[^[:digit:]]/, "", $1 )
+  awk -v now=$(date +%s) '$1 ~ /\/[0-9]+$/ {
+      gsub( /[^0-9]/, "", $1 )
       list[$1]="PTY " $1 " is " now-$2 " seconds idle and owned by " $3
       if( $1==ENVIRON["our_pty"] ) list[$1]=list[$1] " ** this is us **"}
       END {for(i in list) print list[i]}'


### PR DESCRIPTION
Bug fix: The getidle function uses the gawk function systime. Now systime inside awk is replaced by calling date in the shell. This should be work with POSIX conform awk implementation.