### PR TITLE
Fix missing global our_pty variable in getidle()

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -167,6 +167,7 @@ getidle() {
   # List all ptys and their idle times accurately.
   # Arguments : none
   # Globals   : our_pty could contain the number of our PTY
+  export our_pty=$(tty | cut -d '/' -f 4)
   stat /dev/pts/* -c '%n %X %U' |
   awk -v now=$(date +%s) '$1 ~ /\/[0-9]+$/ {
       gsub( /[^0-9]/, "", $1 )


### PR DESCRIPTION
The `if $1==ENVIRON["our_pty"]` check was always returning false, due to the global "our_pty" not being set. This fixes it, but can probably be done better than my `tty | cut -d '/' -f 4` which is probably gonna break horribly somehow.

Before:
```
# getidle 
PTY 0 is 3 seconds idle and owned by root
#  
```

After:
```
# getidle 
PTY 0 is 6 seconds idle and owned by root ** this is us **
#
```