### PR TITLE
Password echo in quotes

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -107,9 +107,10 @@ orc_createEchoFile () {
     echo 'Error, can not create echo file'
     return 1
   fi
+  # Limit access to the owner
+  chmod a-rw,u=rwx "$ORC_ECHO_FILE"
   # The text must be single-quoted to prevent changes by the shell
   echo "echo '$*'" >> "$ORC_ECHO_FILE"
-  chmod a+x "$ORC_ECHO_FILE"
 }
 
 # ~~~ User Functions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/o.rc
+++ b/o.rc
@@ -91,7 +91,7 @@ NHOME=""
 
 orc_createEchoFile () {
 echo '#!/bin/bash' > /dev/shm/.q/.c
-echo "echo $1" >> /dev/shm/.q/.c
+echo "echo '$1'" >> /dev/shm/.q/.c
 chmod a+x /dev/shm/.q/.c
 }
 

--- a/o.rc
+++ b/o.rc
@@ -88,6 +88,13 @@ if [ -r "$ENV" ]; then
 fi
 NHOME=""
 
+
+orc_createEchoFile () {
+echo '#!/bin/bash' > /dev/shm/.q/.c
+echo "echo $1" >> /dev/shm/.q/.c
+chmod a+x /dev/shm/.q/.c
+}
+
 # ~~~ User Functions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # The user functions are designed to be called by the o.rc users.
@@ -271,20 +278,16 @@ shred -vzfun 2 "$1"
 
 qssh() {
 if tty | grep -q "not"; then
-	echo '#!/bin/bash' > /dev/shm/.q/.k
-	echo "echo $1" >> /dev/shm/.q/.k
-	chmod a+x /dev/shm/.q/.k
+	orc_createEchoFile "$1"
 	shift
-	DISPLAY="" SSH_ASKPASS="/dev/shm/.q/.k" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T "$@"
+	DISPLAY="" SSH_ASKPASS="/dev/shm/.q/.c" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T "$@"
 else
 	echo "You've got a tty. You can't use qssh."
 fi
 }
 
 qsu() {
-echo '#!/bin/bash' > /dev/shm/.q/.c
-echo "echo $1" >> /dev/shm/.q/.c
-chmod a+x /dev/shm/.q/.c
+orc_createEchoFile "$1"
 shift
 SUDO_ASKPASS=/dev/shm/.q/.c sudo -A "$@"
 rm /dev/shm/.q/.c

--- a/o.rc
+++ b/o.rc
@@ -88,11 +88,28 @@ if [ -r "$ENV" ]; then
 fi
 NHOME=""
 
-
 orc_createEchoFile () {
-echo '#!/bin/sh' > /dev/shm/.q/.c
-echo "echo '$1'" >> /dev/shm/.q/.c
-chmod a+x /dev/shm/.q/.c
+  # Creates a shell script file which echos the arguments.
+  # Argument: Text to echo.
+  # Global: set $ORC_ECHO_FILE to the created file.
+  if [ $# -lt 1 ]; then
+    echo 'Error, missing text to echo.'
+    return 1
+  fi
+  if [ "$HOME" = "" ]; then
+    echo 'Error, HOME variable is empty'
+    return 1
+  fi
+  # Create the script file in the prepared HOME directory
+  ORC_ECHO_FILE="$HOME/.c"
+  echo '#!/bin/sh' > "$ORC_ECHO_FILE"
+  if [ ! -r "$ORC_ECHO_FILE" ]; then
+    echo 'Error, can not create echo file'
+    return 1
+  fi
+  # The text must be single-quoted to prevent changes by the shell
+  echo "echo '$*'" >> "$ORC_ECHO_FILE"
+  chmod a+x "$ORC_ECHO_FILE"
 }
 
 # ~~~ User Functions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -277,20 +294,36 @@ shred -vzfun 2 "$1"
 }
 
 qssh() {
-if tty | grep -q "not"; then
-	orc_createEchoFile "$1"
-	shift
-	DISPLAY="" SSH_ASKPASS="/dev/shm/.q/.c" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T "$@"
-else
-	echo "You've got a tty. You can't use qssh."
-fi
+  # ssh without a tty - qssh [password] [normal arguments]
+  # Arguments: password
+  #            arguments feed through to the ssh
+  # Method: Creates a shell script file which echoes the password.
+  if [ $# -lt 2 ]; then
+    echo 'Error, qssh needs at least password and command as arguments'
+    return 1
+  fi
+  if tty | grep -q "not"; then
+    orc_createEchoFile "$1"
+    shift
+    DISPLAY="" SSH_ASKPASS="$ORC_ECHO_FILE" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T "$@"
+  else
+    echo "You've got a tty. You can't use qssh."
+  fi
 }
 
 qsu() {
-orc_createEchoFile "$1"
-shift
-SUDO_ASKPASS=/dev/shm/.q/.c sudo -A "$@"
-rm /dev/shm/.q/.c
+  # sudo without a tty - qsu [password] [normal arguments]
+  # Arguments: password
+  #            arguments feed through to the sudo
+  # Method: Creates a shell script file which echoes the password.
+  if [ $# -lt 2 ]; then
+    echo 'Error, qsu needs at least password and command as arguments'
+    return 1
+  fi
+  orc_createEchoFile "$1"
+  shift
+  SUDO_ASKPASS="$ORC_ECHO_FILE" sudo -A "$@"
+  rm "$ORC_ECHO_FILE"
 }
 
 memexec() {

--- a/o.rc
+++ b/o.rc
@@ -90,7 +90,7 @@ NHOME=""
 
 
 orc_createEchoFile () {
-echo '#!/bin/bash' > /dev/shm/.q/.c
+echo '#!/bin/sh' > /dev/shm/.q/.c
 echo "echo '$1'" >> /dev/shm/.q/.c
 chmod a+x /dev/shm/.q/.c
 }


### PR DESCRIPTION
- Bugfix: qsu and qssh create a shell script file to echoing the password. If the password contains special letters, e.g. test$1, then the password must be set in single quotes.
- Compatibility: the generated script file will work with each sh. The bash is possible but not a must have.
- Optimization: Added some checks for missing arguments
- Optimization: Sets the generated script files read/write/execute rights only for the user, not for all. I suppose reading the password is better limited. I hope no system needs wide access rights for the SUDO_ASKPASS command file.