### PR TITLE
Portscan tools

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -53,6 +53,24 @@ sys.stdout.write(request.read())
   fi
 }
 
+orc_tryTcpConnection () {
+  # Try to open a TCP connection to given host and port.
+  # Argument: host name or host IP address
+  #           TCP port number
+  # Return: 0 if and ony if TCP connection could be opened
+  if [ $# -ne 2 ]; then
+    echo 'Error: need host and TCP port as arguments'
+    return 1
+  fi
+  if orc_existsProg bash; then
+    bash -c "echo '' > /dev/tcp/$1/$2" 2>/dev/null
+  else
+    echo 'Error: no tool to open TCP connection found'
+    return 1
+  fi
+}
+
+
 # ~~~ Helper Functions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # In the section of the internal helper functions are collected.
@@ -406,8 +424,7 @@ portscan() {
   echo "Starting portscan of $1 ..."
   for port in  21 22 23 80 443 8080 8443 129 445 3389 3306
   do
-    bash -c "echo '' > /dev/tcp/$1/$port" 2>/dev/null
-    if echo $? | grep -q 0; then
+    if orc_tryTcpConnection "$1" "$port"; then
       echo "Host $1 TCP port $port open"
     fi
   done

--- a/o.rc
+++ b/o.rc
@@ -396,14 +396,21 @@ echo "Checking to see if we're in one giant simulation..."
 }
 
 portscan() {
-porta="21 22 23 80 443 8080 8443 129 445 3389 3306"
-echo "Starting portscan..."
-echo "$porta" | tr ' ' '\n' | while read i;do
-bash -c "echo '' > /dev/tcp/$1/$i" 2>/dev/null
-	if echo $? | grep -q 0; then
-	echo "Host $1 port $i open"
-	fi
-done
+  # Run a portscan against common ports
+  # List ports which allow TCP connections.
+  # Argument: Name or IP of the target box.
+  if [ $# -ne 1 ]; then
+    echo 'Error, portscan needs one host name or host address'
+    return 1
+  fi
+  echo "Starting portscan of $1 ..."
+  porta="21 22 23 80 443 8080 8443 129 445 3389 3306"
+  echo "$porta" | tr ' ' '\n' | while read i;do
+    bash -c "echo '' > /dev/tcp/$1/$i" 2>/dev/null
+    if echo $? | grep -q 0; then
+      echo "Host $1 port $i open"
+    fi
+  done
 }
 
 fpssh() {

--- a/o.rc
+++ b/o.rc
@@ -404,11 +404,11 @@ portscan() {
     return 1
   fi
   echo "Starting portscan of $1 ..."
-  porta="21 22 23 80 443 8080 8443 129 445 3389 3306"
-  echo "$porta" | tr ' ' '\n' | while read i;do
-    bash -c "echo '' > /dev/tcp/$1/$i" 2>/dev/null
+  for port in  21 22 23 80 443 8080 8443 129 445 3389 3306
+  do
+    bash -c "echo '' > /dev/tcp/$1/$port" 2>/dev/null
     if echo $? | grep -q 0; then
-      echo "Host $1 port $i open"
+      echo "Host $1 TCP port $port open"
     fi
   done
 }

--- a/o.rc
+++ b/o.rc
@@ -62,7 +62,10 @@ orc_tryTcpConnection () {
     echo 'Error: need host and TCP port as arguments'
     return 1
   fi
-  if orc_existsProg nc; then
+  if orc_existsProg nmap; then
+    # TCP connect scan with nmap
+    nmap -oG - -Pn -sT -p "$2" "$1" | grep -q "/open/tcp/"
+  elif orc_existsProg nc; then
     # Open connection with netcat
     # Do not use option -N here because not all nc implementations support
     # this (e.g. busybox).

--- a/o.rc
+++ b/o.rc
@@ -62,7 +62,14 @@ orc_tryTcpConnection () {
     echo 'Error: need host and TCP port as arguments'
     return 1
   fi
-  if orc_existsProg bash; then
+  if orc_existsProg nc; then
+    # Open connection with netcat
+    # Do not use option -N here because not all nc implementations support
+    # this (e.g. busybox).
+    echo '' | nc -w1 "$1" "$2" 2>/dev/null
+  elif orc_existsProg bash; then
+    # Open a connection with the bash.
+    # This is a bash extension. POSIX shell will not support this.
     bash -c "echo '' > /dev/tcp/$1/$2" 2>/dev/null
   else
     echo 'Error: no tool to open TCP connection found'

--- a/o.rc
+++ b/o.rc
@@ -42,6 +42,7 @@ orc_loadURL () {
              print get $url;
              ' -- "$1"
   elif orc_existsProg python; then
+    # Do not insert the code because python is insert sensitive.
     PYTHONHTTPSVERIFY=0 python -c '
 import sys, urllib2
 request = urllib2.urlopen(sys.argv[1])
@@ -62,9 +63,25 @@ orc_tryTcpConnection () {
     echo 'Error: need host and TCP port as arguments'
     return 1
   fi
-  if orc_existsProg nmap; then
+  if orc_existsProg bash; then
+    # Open a connection with the bash.
+    # This is a bash extension. POSIX shell will not support this.
+    bash -c "echo '' > /dev/tcp/$1/$2" 2>/dev/null
+  elif orc_existsProg nmap; then
     # TCP connect scan with nmap
     nmap -oG - -Pn -sT -p "$2" "$1" | grep -q "/open/tcp/"
+  elif orc_existsProg python; then
+    # TCP connection open with python version 2
+    # Do not insert the code because python is insert sensitive.
+python -c '
+import socket,sys
+try:
+  s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+  s.connect((sys.argv[1],int(sys.argv[2])))
+except:
+  sys.exit(1)
+sys.exit(0)
+  ' "$1" "$2"
   elif orc_existsProg nc; then
     # Open connection with netcat
     # Do not use option -N here because not all nc implementations support


### PR DESCRIPTION
- Increases the portability if the portscan function: Now bash, nmap, python (version 2) or nc (netcat) are used. Hence if o.rc runs in a POSIX shell on a system without bash a portscan may be possible with one of the other tools.
- The TCP connection check is isolated in a function orc_tryTcpConnection. This function may be used later to check the connection in other functions, see issue #43. 