### PR TITLE
Getnet rework

### DIFF
--- a/o.rc
+++ b/o.rc
@@ -703,6 +703,34 @@ prochide() {
 
 # >> compatibility layer
 
+#
+# orc_local
+#
+# Local variables are a useful help but some shells support 'local',
+# some shells support 'typeset' and some shells support both.
+# Here the alias orc_local is defined to ensure a wide support.
+# Use orc_local only in the form 'orc_local var' not in the form
+# 'orc_local var=value' because the second form is not supported by
+# all shells. Also orc_local should be the first statement in a
+# function.
+#
+if command -v local > /dev/null; then
+  # dash, bash, ash, mksh supports local
+  alias orc_local='local'
+elif command -v typeset > /dev/null; then
+  # ksh, mksh, bash supports typeset
+  alias orc_local='typeset'
+else
+  alias orc_local='orc_noop'
+  echo "Warning: no local variables could cause trouble" >&2
+fi
+
+
+orc_noop() {
+  # No operation.
+  return
+}
+
 
 orc_listArp() {
   # List IP addresses in the ARP table.
@@ -725,27 +753,26 @@ orc_listBroadcastAddress() {
   # List the broadcast addresses of interfaces.
   # Arguments: None
   # Output to stdout: IPv4 broadcast addresses, one per line
-  if orc_existsProg ifconfig; then
+  if orc_existsProg ifconfigXXXX; then
     # Attention: ifconfig output is different on the systems.
     # The up/down status is not checked because it may fail on different
     # output formats.
     ifconfig |
-    awk 'match($0,/inet.* [Bb][Rr]?[Oo]?[Aa]?[Dd]?[Cc][Aa][Ss][Tt][: ]*([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
-	  tmp = substr($0,RSTART,RLENGTH)
-          match(tmp,/[Bb][Rr]?[Oo]?[Aa]?[Dd]?[Cc][Aa][Ss][Tt][: ]*([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/)
-	  tmp = substr(tmp,RSTART,RLENGTH)
-          match(tmp,/([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/)
-          print substr(tmp,RSTART,RLENGTH)
-          }'
+    mawk '
+      match($0,/inet.* broadcast +([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
+        # ifconfig version nettools 2.10
+        split(substr($0,RSTART,RLENGTH),tmp )
+        print tmp[2] }
+      match($0,/Bcast[: ]+([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
+        # ifconfig version busybox 1.27
+        split(substr($0,RSTART,RLENGTH),tmp,/[: ]+/)
+        print tmp[2] }'
   elif orc_existsProg ip; then
     ip addr show |
-    awk 'match($0,/inet.*[Bb][Rr][Dd][: ]*([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
-          tmp = substr($0,RSTART,RLENGTH)
-          match(tmp,/[Bb][Rr][Dd][: ]*([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/)
-          tmp = substr(tmp,RSTART,RLENGTH)
-          match(tmp,/([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/)
-          print substr(tmp,RSTART,RLENGTH)
-          }'
+    awk '
+      match($0,/brd +([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
+        split(substr($0,RSTART,RLENGTH),tmp)
+        print tmp[2] }'
   else
     echo 'Error: can not list broadcast addresses. Found no tool' >&2
   fi
@@ -804,17 +831,20 @@ orc_filterIpAddress() {
       # it is a IPv4 address
       tmp = substr($0,RSTART,RLENGTH)
       if (match(tmp,/\..+\..+\./))
-        print tmp }
+        print tmp
+        next }
     match($0,/([a-f0-9]?[a-f0-9]?[a-f0-9]?[a-f0-9]?:)+[a-f0-9]+/) {
       # it is a IPv6 address or an ethernet address with lower case letters
       tmp = substr($0,RSTART,RLENGTH)
       if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
-        print tmp }
-    match($0,/([A-F0-9]?[a-f0-9]?[A-F0-9]?[A-F0-9]?:)+[A-F0-9]+/) {
+        print tmp
+        next }
+    match($0,/([A-F0-9]?[A-F0-9]?[A-F0-9]?[A-F0-9]?:)+[A-F0-9]+/) {
       # it is a IPv6 address or an ethernet address with upper case letters
       tmp = substr($0,RSTART,RLENGTH)
       if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
-        print tmp }'
+        print tmp
+        next }'
 }
 
 
@@ -822,6 +852,7 @@ orc_pingBroadcast() {
   # Ping the Broadcast IP addresses of all interfaces.
   # Arguments: None
   # Output to stdout
+  orc_local addr
   for addr in $(orc_listBroadcastAddress); do
     ping -c 3 -i 10 -b "$addr"
   done
@@ -832,13 +863,14 @@ orc_listHomes() {
   # List the home directories of the users.
   # Argument: None.
   # Output to stdout: One home directory per line.
+  orc_local dir
   getent passwd |
   # filter: home directory in field 6, directory only once
   awk -F ':' 'hit[$6] == 0 {hit[$6]=1; print $6}' |
   # filter: only existing directories, no dummy entries
-  while read -r i; do
-    if [ -d "$i" ]; then
-      echo "$i"
+  while read -r dir; do
+    if [ -d "$dir" ]; then
+      echo "$dir"
     fi
   done
 }
@@ -875,11 +907,12 @@ orc_collectOtherHostsInfo() {
   # Arguments: None
   # Output to $HOME/kh archive file
   # Collect output files in $OUTP
-  OUTP=$HOME/files/
+  orc_local dir
+  OUTP="$HOME/files/"
   mkdir --mode 700 "$OUTP"
   echo 'collect all readable .ssh/known_hosts files'
-  for i in $(orc_listHomes); do
-    orc_testAndCopy "$i/.ssh/known_hosts" "$OUTP"
+  for dir in $(orc_listHomes); do
+    orc_testAndCopy "$dir/.ssh/known_hosts" "$OUTP"
   done
   echo 'try /etc/ssh/known_hosts file'
   orc_testAndCopy /etc/ssh/known_hosts "$OUTP"
@@ -902,27 +935,28 @@ orc_IP4toInteger() {
   # Converts a IPv4 address into a number.
   # Argument: IPv4 address
   # Output to stdout: integer number
+  orc_local str value
   if [ $# -ne 1 ]; then
     echo 'Error: IPv4 address must be given as argument' >&2
     return 1
   fi
   # get first number by removing the last 3 numbers
-  orc_tmp_value=${1%.*.*.*}
-  if [ "$orc_tmp_value" = "" ]; then
+  value=${1%.*.*.*}
+  if [ "$value" = "" ]; then
     echo 'Error: no IPv4 address given' >&2
     return 1
   fi
   # get the last 2 numbers by removing the first number
-  orc_tmp_str="${1#*.}"
+  str="${1#*.}"
   # the second number
-  orc_tmp_value=$(( orc_tmp_value * 256 + ${orc_tmp_str%.*.*} ))
-  orc_tmp_str="${orc_tmp_str#*.}"
+  value=$(( value * 256 + ${str%.*.*} ))
+  str="${str#*.}"
   # the third number
-  orc_tmp_value=$(( orc_tmp_value * 256 + ${orc_tmp_str%.*} ))
-  orc_tmp_str="${orc_tmp_str#*.}"
+  value=$(( value * 256 + ${str%.*} ))
+  str="${str#*.}"
   # the last number
-  orc_tmp_value=$(( orc_tmp_value * 256 + orc_tmp_str ))
-  echo $orc_tmp_value
+  value=$(( value * 256 + str ))
+  echo $value
 }
 
 
@@ -930,6 +964,7 @@ orc_integerToIP4() {
   # Converts a number into an IPv4 address
   # Argument: integer number
   # Output to stdout: IPv4 address in dotted format.
+  orc_local str value
   if [ $# -ne 1 ]; then
     echo 'Error: number must given as argument' >&2
     return 1
@@ -938,15 +973,15 @@ orc_integerToIP4() {
     echo 'Error: number out of range' >&2
     return 1
   fi
-  orc_tmp_str="$(( $1 % 256 ))"
-  orc_tmp_value=$(( ($1 - ($1 % 256)) / 256 ))
-  orc_tmp_str="$(( orc_tmp_value % 256 )).$orc_tmp_str"
-  orc_tmp_value=$(( (orc_tmp_value - (orc_tmp_value % 256)) / 256 ))
-  orc_tmp_str="$(( orc_tmp_value % 256 )).$orc_tmp_str"
-  orc_tmp_value=$(( (orc_tmp_value - (orc_tmp_value % 256)) / 256 ))
-  orc_tmp_str="$(( orc_tmp_value % 256 )).$orc_tmp_str"
-  orc_tmp_value=$(( (orc_tmp_value - (orc_tmp_value % 256)) / 256 ))
-  echo "$orc_tmp_str"
+  str="$(( $1 % 256 ))"
+  value=$(( ($1 - ($1 % 256)) / 256 ))
+  str="$(( value % 256 )).$str"
+  value=$(( (value - (value % 256)) / 256 ))
+  str="$(( value % 256 )).$str"
+  value=$(( (value - (value % 256)) / 256 ))
+  str="$(( value % 256 )).$str"
+  value=$(( (value - (value % 256)) / 256 ))
+  echo "$str"
 }
 
 
@@ -984,6 +1019,7 @@ orc_lengthToIP4netmask() {
   # Converts the fixed length number into the IPv4 bitmask.
   # Argument fixed length
   # Output to stdout: IPv4 bitmask
+  orc_local value counter
   if [ $# -ne 1 ]; then
     echo 'Error: fixed length size must be given' >&2
     return 1
@@ -992,14 +1028,14 @@ orc_lengthToIP4netmask() {
     echo 'Error: length out of range' >&2
     return 1
   fi
-  orc_tmp_value=0
-  orc_tmp_counter=$1
-  while [ "$orc_tmp_counter" -gt 0 ]; do
-    orc_tmp_counter=$(( orc_tmp_counter - 1 ))
+  value=0
+  counter=$1
+  while [ "$counter" -gt 0 ]; do
+    counter=$(( counter - 1 ))
     # shift current bits 1 right and set the topmost bit to 1.
-    orc_tmp_value=$(( (orc_tmp_value >> 1) + 2147483648 ))
+    value=$(( (value >> 1) + 2147483648 ))
   done
-  orc_integerToIP4 $orc_tmp_value
+  orc_integerToIP4 $value
 }
 
 
@@ -1008,28 +1044,31 @@ orc_pingIP4Localnet() {
   # and protocol if host is alive.
   # Arguments: One IPv4 address in dotted format
   #            The netmask in dotted format
+  orc_local myaddr mask value lastvalue address
   if [ $# -ne 2 ]; then
     echo 'need address and netmask as arguments' >&2
     return 1;
   fi
-  orc_tmp_addr=$(orc_IP4toInteger "$1")
-  orc_tmp_mask=$(orc_IP4toInteger "$2")
-  orc_tmp_value=$(orc_firstIp4integer "$orc_tmp_addr" "$orc_tmp_mask")
-  orc_tmp_last=$(orc_lastIP4integer "$orc_tmp_addr" "$orc_tmp_mask")
-  while [ "$orc_tmp_value" -le "$orc_tmp_last" ]; do
-    orc_tmp_ip=$(orc_integerToIP4 "$orc_tmp_value")
-    if ping -c1 -n "$orc_tmp_ip" > /dev/null
+  myaddr=$(orc_IP4toInteger "$1")
+  mask=$(orc_IP4toInteger "$2")
+  value=$(orc_firstIp4integer "$myaddr" "$mask")
+  lastvalue=$(orc_lastIP4integer "$myaddr" "$mask")
+  while [ "$value" -le "$lastvalue" ]; do
+    address=$(orc_integerToIP4 "$value")
+    if ping -c1 -n "$address" > /dev/null
     then
-      echo "$orc_tmp_ip is alive"
+      echo "$address is alive"
     fi
-    orc_tmp_value=$(( orc_tmp_value + 1 ))
+    value=$(( value + 1 ))
   done
 }
 
 
 # >> the user level function
 
+
 getnet2() {
+  orc_local addr mask
   echo "Let's see what we can find on the network..."
   echo 'IPv4 and IPv6 addresses in the ARP table:'
   orc_listArp
@@ -1039,6 +1078,11 @@ getnet2() {
   echo "Broadcast ping is done."
   echo "Pulling known hosts from some files and writing to $HOME/kh ..."
   orc_collectOtherHostsInfo
+  if [ $((256*256*256*128)) -lt 0 ]; then
+    echo 'Warning: no 64 bit integers in the shell.
+       Can not calculate IP addresses' >&2
+    return 1
+  fi
   echo "Pinging local IPv4 addresse in background writing $HOME/ips ..."
   orc_inetAddressAndMask |
    while read -r addr mask; do

--- a/o.rc
+++ b/o.rc
@@ -753,7 +753,7 @@ orc_listBroadcastAddress() {
   # List the broadcast addresses of interfaces.
   # Arguments: None
   # Output to stdout: IPv4 broadcast addresses, one per line
-  if orc_existsProg ifconfigXXXX; then
+  if orc_existsProg ifconfig; then
     # Attention: ifconfig output is different on the systems.
     # The up/down status is not checked because it may fail on different
     # output formats.

--- a/o.rc
+++ b/o.rc
@@ -696,50 +696,27 @@ prochide() {
   bash -c "exec -a \"$LONGARG\" $*"
 }
 
-# ~~~ Working section getnet~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~ Working section getnet ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Create the new getnet function here.
 # First place all needed help functions here. Later move the functions
 # into the correct positions in the file.
 
-
-orc_filterIpAddress() {
-  # Filter strings looks like an IPv4 or IPv6 address.
-  # Maximal one address per line is expected.
-  # The function passes all valid IPv4 addresses.
-  # Some valid IPv6 are not pass.
-  # Ethernet addresses do not pass.
-  # Arguments: none
-  # Reads stdin and writes to stdout
-  # Attention: match(s,p,a) is not supported by mawk.
-  # Pattern repeat operator {n} is not supported by mawk.
-  awk '
-    match($0,/([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
-       tmp = substr($0,RSTART,RLENGTH)
-       if (match(tmp,/\..+\..+\./))
-          print tmp }
-    match($0,/([a-f0-9]?[a-f0-9]?[a-f0-9]?[a-f0-9]?:)+[a-f0-9]+/) {
-       tmp = substr($0,RSTART,RLENGTH)
-       if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
-          print tmp }
-    match($0,/([A-F0-9]?[a-f0-9]?[A-F0-9]?[A-F0-9]?:)+[A-F0-9]+/) {
-       tmp = substr($0,RSTART,RLENGTH)
-       if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
-          print tmp }'
-}
+# >> compatibility layer
 
 
 orc_listArp() {
   # List IP addresses in the ARP table.
+  # List only resolved addresses.
   # Arguments: None
   # Output to stdout: List of IP addresses, one address per line
   if orc_existsProg arp; then
     # use short switches -a, -n because the long versions are not
     # supported on all systems, e.g. on busybox.
-    arp -na | grep -v incomplete | orc_filterIpAddress
+    arp -na | grep -iv 'incomplete' | orc_filterIpAddress
   elif orc_existsProg ip; then
-    ip neigh show | orc_filterIpAddress
+    ip neigh show | grep -iv 'FAILED' | orc_filterIpAddress
   else
-    echo 'Can not list ARP content. Found no tool' >&2
+    echo 'Error: Can not list ARP content. Found no tool' >&2
   fi
 }
 
@@ -770,8 +747,74 @@ orc_listBroadcastAddress() {
           print substr(tmp,RSTART,RLENGTH)
           }'
   else
-    echo "Can not list broadcast addresses. Found no tool" >&2
+    echo 'Error: can not list broadcast addresses. Found no tool' >&2
   fi
+}
+
+
+orc_inetAddressAndMask() {
+  # Lists the IPv4 addresses and netmask of the interfaces.
+  # Arguments: None
+  # Output to stdout: Address and mask space separated.
+  #                   One line per active interface
+  if orc_existsProg ifconfig; then
+    ifconfig |
+    awk '
+      match($0,/inet +[0-9\.]+ +netmask +[0-9\.]+ +broadcast/) {
+        # matching ifconfig 2.10 Linux
+        split(substr($0,RSTART,RLENGTH),item)
+	print item[2] " " item[4]
+      }
+      match($0,/inet +addr[: ]+[0-9\.*]+ +Bcast[: ]+[0-9\.]+ +Mask[: ]+[0-9\.]+/) {
+        # matching ifconfig Busybox 1.27
+	split(substr($0,RSTART,RLENGTH),item,/[: ]+/)
+	print item[3] " " item[7]
+        }'
+  elif orc_existsProg ip;  then
+    ip addr show |
+    awk '
+      match($0,/inet +[0-9\.]+\/[0-9]+ brd/) {
+        split(substr($0,RSTART,RLENGTH),item,/[\/ ]+/)
+	print item[2] " " item[3]
+     }' |
+     while read -r addr bits; do
+       echo "$addr" "$(orc_lengthToIP4netmask "$bits")"
+     done
+  else
+    echo "Error: can not list IP addresses, no tool found" >&2
+  fi
+}
+
+
+# >> helper functions
+
+
+orc_filterIpAddress() {
+  # Filter strings looks like an IPv4 or IPv6 address.
+  # Maximal one address per line is expected.
+  # The function passes all valid IPv4 addresses.
+  # Some valid IPv6 are not pass.
+  # Ethernet addresses do not pass.
+  # Arguments: none
+  # Reads stdin and writes to stdout
+  # Attention: match(s,p,a) is not supported by mawk.
+  # Pattern repeat operator {n} is not supported by mawk.
+  awk '
+    match($0,/([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
+      # it is a IPv4 address
+      tmp = substr($0,RSTART,RLENGTH)
+      if (match(tmp,/\..+\..+\./))
+        print tmp }
+    match($0,/([a-f0-9]?[a-f0-9]?[a-f0-9]?[a-f0-9]?:)+[a-f0-9]+/) {
+      # it is a IPv6 address or an ethernet address with lower case letters
+      tmp = substr($0,RSTART,RLENGTH)
+      if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
+        print tmp }
+    match($0,/([A-F0-9]?[a-f0-9]?[A-F0-9]?[A-F0-9]?:)+[A-F0-9]+/) {
+      # it is a IPv6 address or an ethernet address with upper case letters
+      tmp = substr($0,RSTART,RLENGTH)
+      if (match(tmp,/:.*:.*:.*:.*:/) && match(tmp,/^..:..:..:..:..:..$/)==0)
+        print tmp }'
 }
 
 
@@ -780,7 +823,7 @@ orc_pingBroadcast() {
   # Arguments: None
   # Output to stdout
   for addr in $(orc_listBroadcastAddress); do
-    ping -c 3 -i 10 -b $addr
+    ping -c 3 -i 10 -b "$addr"
   done
 }
 
@@ -790,7 +833,9 @@ orc_listHomes() {
   # Argument: None.
   # Output to stdout: One home directory per line.
   getent passwd |
+  # filter: home directory in field 6, directory only once
   awk -F ':' 'hit[$6] == 0 {hit[$6]=1; print $6}' |
+  # filter: only existing directories, no dummy entries
   while read -r i; do
     if [ -d "$i" ]; then
       echo "$i"
@@ -812,11 +857,11 @@ orc_testAndCopy() {
   # Arguments: File to copy.
   #            Destination directory.
   if [ $# -ne 2 ]; then
-    echo 'need two arguments: file and destination' >&2
+    echo 'Error: need two arguments: file and destination' >&2
     return 1
   fi
   if [ ! -d "$2" ]; then
-    echo "2nd parameter ($2) must be a directory" >&2
+    echo "Error: 2nd parameter ($2) must be a directory" >&2
     return 1
   fi
   if [ -r "$1" ]; then
@@ -848,40 +893,49 @@ orc_collectOtherHostsInfo() {
     # Remove the single files. Keep only the archive file.
     rm -rf "$OUTP"
   else
-    echo "Error, can not archive, the files are in $OUTP"
+    echo "Error: can not archive, the files are in $OUTP" >&2
   fi
 }
 
 
-orc_ip4toInteger() {
+orc_IP4toInteger() {
   # Converts a IPv4 address into a number.
   # Argument: IPv4 address
   # Output to stdout: integer number
   if [ $# -ne 1 ]; then
-    echo 'IPv4 must given as argument' >&2
+    echo 'Error: IPv4 address must be given as argument' >&2
     return 1
   fi
+  # get first number by removing the last 3 numbers
   orc_tmp_value=${1%.*.*.*}
+  if [ "$orc_tmp_value" = "" ]; then
+    echo 'Error: no IPv4 address given' >&2
+    return 1
+  fi
+  # get the last 2 numbers by removing the first number
   orc_tmp_str="${1#*.}"
+  # the second number
   orc_tmp_value=$(( orc_tmp_value * 256 + ${orc_tmp_str%.*.*} ))
   orc_tmp_str="${orc_tmp_str#*.}"
+  # the third number
   orc_tmp_value=$(( orc_tmp_value * 256 + ${orc_tmp_str%.*} ))
   orc_tmp_str="${orc_tmp_str#*.}"
+  # the last number
   orc_tmp_value=$(( orc_tmp_value * 256 + orc_tmp_str ))
   echo $orc_tmp_value
 }
 
 
-orc_integerToIp4() {
+orc_integerToIP4() {
   # Converts a number into an IPv4 address
   # Argument: integer number
   # Output to stdout: IPv4 address in dotted format.
   if [ $# -ne 1 ]; then
-    echo 'Number must given as argument' >&2
+    echo 'Error: number must given as argument' >&2
     return 1
   fi
   if [ "$1" -lt 1 ] || [ "$1" -gt 4294967296 ]; then
-    echo 'Number out of range' >&2
+    echo 'Error: number out of range' >&2
     return 1
   fi
   orc_tmp_str="$(( $1 % 256 ))"
@@ -902,83 +956,54 @@ orc_firstIp4integer() {
   #           Netmask as integer, NOT dotted format
   # Output to stdout: first address in the LAN as integer
   if [ $# -ne 2 ]; then
-    echo 'Address and netmask must be given' >&2
+    echo 'Error: address and netmask must be given' >&2
     return 1
   fi
+  # +1 because all bits 0 outside the bitmask is not allowed, it
+  # is the address of the subnet, not of a host.
   echo $(( ($1 & $2) + 1 ))
 }
 
 
-orc_lastIp4integer() {
+orc_lastIP4integer() {
   # Last IPv4 address in a LAN.
   # Argument: One address as integer, NOT dotted format
   #           Netmask as integer, NOT dotted format
   # Output to stdout: last address in the LAN as integer
   if [ $# -ne 2 ]; then
-    echo 'Address and netmask must be given' >&2
+    echo 'Error: address and netmask must be given' >&2
     return 1
   fi
-  echo $(( ($1 & $2) + (4294967295  & ~$2) ))
+  # 4294967295 = 31 bits 1 and last bit 0. All bits 1 outside the
+  # netmask is the broadcast address of the subnet.
+  echo $(( ($1 & $2) + (4294967295 & ~$2) ))
 }
 
 
-orc_lengthToIp4mask() {
+orc_lengthToIP4netmask() {
   # Converts the fixed length number into the IPv4 bitmask.
   # Argument fixed length
   # Output to stdout: IPv4 bitmask
   if [ $# -ne 1 ]; then
-    echo 'Fixed length size must be given' >&2
+    echo 'Error: fixed length size must be given' >&2
     return 1
   fi
   if [ "$1" -lt 1 ] || [ "$1" -gt 31 ]; then
-    echo 'Length out of range' >&2
+    echo 'Error: length out of range' >&2
     return 1
   fi
   orc_tmp_value=0
   orc_tmp_counter=$1
   while [ "$orc_tmp_counter" -gt 0 ]; do
     orc_tmp_counter=$(( orc_tmp_counter - 1 ))
+    # shift current bits 1 right and set the topmost bit to 1.
     orc_tmp_value=$(( (orc_tmp_value >> 1) + 2147483648 ))
   done
-  orc_integerToIp4 $orc_tmp_value
+  orc_integerToIP4 $orc_tmp_value
 }
 
 
-orc_inetAddressAndMask() {
-  # Lists the IPv4 addresses and netmask of the interfaces.
-  # Arguments: None
-  # Output to stdout: Address and mask space separated.
-  #                   One line per active interface
-  if orc_existsProg ifconfig; then
-    ifconfig |
-    awk '
-      match($0,/inet +[0-9\.]+ +netmask +[0-9\.]+ +broadcast/) {
-        # matching ifconfig 2.10 Linux
-        split(substr($0,RSTART,RLENGTH),item)
-	print item[2] " " item[4]
-      }
-      match($0,/inet +addr[: ]+[0-9\.*]+ +Bcast[: ]+[0-9\.]+ +Mask[: ]+[0-9\.]+/) {
-        # matching ifconfig Busybox 1.27
-	split(substr($0,RSTART,RLENGTH),item,/[: ]+/)
-	print item[3] " " item[7]
-        }'
-  elif orc_existsProg ip;  then
-    ip addr show |
-    awk '
-      match($0,/inet +[0-9\.]+\/[0-9]+ brd/) {
-        split(substr($0,RSTART,RLENGTH),item,/[\/ ]+/)
-	print item[2] " " item[3]
-     }' |
-     while read -r addr bits; do
-       echo "$addr" "$(orc_lengthToIp4mask "$bits")"
-     done
-  else
-    echo "Error: can not list IP addresses, no tool found" >&2
-  fi
-}
-
-
-orc_pingIp4Localnet() {
+orc_pingIP4Localnet() {
   # Ping all local IPv4 addresses
   # and protocol if host is alive.
   # Arguments: One IPv4 address in dotted format
@@ -987,12 +1012,12 @@ orc_pingIp4Localnet() {
     echo 'need address and netmask as arguments' >&2
     return 1;
   fi
-  orc_tmp_addr=$(orc_ip4toInteger "$1")
-  orc_tmp_mask=$(orc_ip4toInteger "$2")
+  orc_tmp_addr=$(orc_IP4toInteger "$1")
+  orc_tmp_mask=$(orc_IP4toInteger "$2")
   orc_tmp_value=$(orc_firstIp4integer "$orc_tmp_addr" "$orc_tmp_mask")
-  orc_tmp_last=$(orc_lastIp4integer "$orc_tmp_addr" "$orc_tmp_mask")
+  orc_tmp_last=$(orc_lastIP4integer "$orc_tmp_addr" "$orc_tmp_mask")
   while [ "$orc_tmp_value" -le "$orc_tmp_last" ]; do
-    orc_tmp_ip=$(orc_integerToIp4 "$orc_tmp_value")
+    orc_tmp_ip=$(orc_integerToIP4 "$orc_tmp_value")
     if ping -c1 -n "$orc_tmp_ip" > /dev/null
     then
       echo "$orc_tmp_ip is alive"
@@ -1001,6 +1026,8 @@ orc_pingIp4Localnet() {
   done
 }
 
+
+# >> the user level function
 
 getnet2() {
   echo "Let's see what we can find on the network..."
@@ -1016,7 +1043,7 @@ getnet2() {
   orc_inetAddressAndMask |
    while read -r addr mask; do
      echo "Pinging subnet around $addr with mask $mask"
-     ( orc_pingIp4Localnet "$addr" "$mask"  >> $HOME/ips )&
+     ( orc_pingIP4Localnet "$addr" "$mask"  >> $HOME/ips )&
    done
 }
 

--- a/o.rc
+++ b/o.rc
@@ -758,7 +758,7 @@ orc_listBroadcastAddress() {
     # The up/down status is not checked because it may fail on different
     # output formats.
     ifconfig |
-    mawk '
+    awk '
       match($0,/inet.* broadcast +([0-9][0-9]?[0-9]?\.)+[0-9][0-9]?[0-9]?/) {
         # ifconfig version nettools 2.10
         split(substr($0,RSTART,RLENGTH),tmp )


### PR DESCRIPTION
Main change:
- a portable orc_local: an alias for local or for typeset. With this construction local variables in some shells (dash, bash, ash, ksh) are possible.

Optimization:
- check 64-bit integer arithmetic is available, the current IPv4 address calculation needs long integers (or unsigned 32-bit integers).
- simplify broadcast search patterns