### PR TITLE
fixed getnet and some shellcheck findings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
-language: shell
+language: generic
 script:
-  # Optimize portability: ShellCheck for bash, POSIX sh and ksh interpreter.
-  - bash -c 'shopt -s globstar; shellcheck -s bash **/*.rc'
-  - bash -c 'shopt -s globstar; shellcheck -s sh **/*.rc'
-  - bash -c 'shopt -s globstar; shellcheck -s ksh **/*.rc'
+  # o.rc
+  #   Static code check with shellcheck tool
+  #   Checks for bash, POSIX shell, dash and ksh
+  - shellcheck -s bash o.rc
+  - shellcheck -s sh o.rc
+  - shellcheck -s dash o.rc
+  - shellcheck -s ksh o.rc
+  # Script build tools in resources
+  #   Static code check with the shellcheck tool
+  #   Checks for the interpreter given in the #! line
+  - shellcheck resources/*.sh
+

--- a/o.rc
+++ b/o.rc
@@ -1166,18 +1166,17 @@ psgrep() {
 }
 
 getescape() {
-ps --no-header aux | awk -F" " '{print $1" "$2}' | grep "^$(id -u)"i | awk '{print $2}' | tr ' ' '\n' | while read -r i; do
-if ls -di --color=never "/proc/$i/root/" | cut -d ' ' -f1 | grep -qe "^2"; then
-	echo "process $i seems to be outside the jail..."
-	fi
-done
-
+  ps --no-header aux | awk -F" " '{print $1" "$2}' | grep "^$(id -u)"i | awk '{print $2}' | tr ' ' '\n' | while read -r i; do
+    if stat -c '%i' "/proc/$i/root/" | grep -qe "^2"; then
+      echo "process $i seems to be outside the jail..."
+    fi
+  done
 }
 
 getjail() {
 TTT=0
 echo "Checking to see if we're in one giant simulation..."
-	if ls -di --color=never / | cut -d ' ' -f1 | grep -vqe "^2"; then
+	if stat -c '%i' '/' | grep -vqe "^2"; then
 	TTT=1
 	echo "We're in a chroot."
 	fi

--- a/o.rc
+++ b/o.rc
@@ -1159,6 +1159,9 @@ psgrep() {
     return 1
   fi
   # don't list this process running the grep
+  # TODO: make a more specific grep with pgrep.
+  # The simple grep searchs in all parts of the ps output.
+  # shellcheck disable=2009
   ps -weFH | grep "$1" | grep -v grep
 }
 

--- a/o.rc
+++ b/o.rc
@@ -1366,16 +1366,19 @@ getexploit () {
 }
 
 getenum() {
-echo "Doing some basic listing of the usual suspects..."
-printf "Kernel: "
-uname -rv
-printf "glibc: "
-readonly libcv="$(ldd "$(command -v id)" | grep --color=never libc.so | awk -F " " '{print $3}') | grep --color=never -i version | grep -v crypt)"
-$libcv
-printf "dbus: "
-dbus-daemon --version | grep --color=never Daemon
-printf "Init system is: "
-ps -p 1 | grep --color=never -v CMD| awk -F " " '{ print $4 }'
+  echo 'Doing some basic listing of the usual suspects...'
+  printf 'Kernel: '
+  uname -rv
+  printf 'glibc: '
+  readonly libcv="$(ldd "$(command -v id)" | grep --color=never libc.so | awk -F " " '{print $3}') | grep --color=never -i version | grep -v crypt)"
+  $libcv
+  printf 'dbus: '
+  dbus-daemon --version | grep --color=never Daemon
+  printf 'Init system is: '
+  # print the true command name of process 1.
+  # ps -p 1 is not supported by all systems, e.g. the busybox.
+  # So select the PID with the AWK tool
+  ps -e -o pid,comm | awk '$1=="1" {print $2}'
 }
 
 
@@ -1441,9 +1444,9 @@ A probably non-comprehensive list of functionality in Orc v$OVERSION.
 [*]        stomp - alias for touch -r (needs arguments)
 [*]        tools - check for common tools
 [*]     dropsuid - drop tiny suid shell - dropsuid > [file]
-[*]      hangup  - terminate someones PTS by killing their SSH process.
+[*]       hangup - terminate someones PTS by killing their SSH process.
 [*]                Very loud, DO NOT USE.
-[*]              - hangup [PTS NUMBER]
+[*]                hangup [PTS NUMBER]
 "
 }
 

--- a/o.rc
+++ b/o.rc
@@ -1476,14 +1476,15 @@ unset HISTFILE
 HISTSIZE=0
 umask 002
 if orc_existsProg ulimit; then
-        echo "coredumps disabled by ulimit"
-	#disabling shellcheck here, we're doing our best
-        # shellcheck disable=SC2039
-	ulimit -c 0
+  echo 'coredumps disabled by ulimit'
+  # disabling shellcheck here, we have checked ulimit existence before.
+  # shellcheck disable=SC2039,SC2169
+  ulimit -c 0
 elif orc_existsProg limit; then
-        echo "coredumps disabled by limit"
-        limit coredumpsize 0
-else echo "no limit/ulimit - coredumps left enabled, careful"
+  echo 'coredumps disabled by limit'
+  limit coredumpsize 0
+else
+  echo 'no limit/ulimit - coredumps left enabled, careful'
 fi
 
 

--- a/o.rc
+++ b/o.rc
@@ -739,7 +739,7 @@ orc_integerToIP4() {
 }
 
 
-orc_firstIp4integer() {
+orc_firstIP4integer() {
   # First IPv4 address in a LAN.
   # Argument: One address as integer, NOT dotted format
   #           Netmask as integer, NOT dotted format
@@ -763,9 +763,12 @@ orc_lastIP4integer() {
     echo 'Error: address and netmask must be given' >&2
     return 1
   fi
-  # ~1 = 31 bits 1 and last bit 0. All bits 1 outside the
-  # netmask is the broadcast address of the subnet.
-  echo $(( ($1 & $2) | (~1 & ~$2) ))
+  # 65535<<16|65534 = 31 bits 1 and last bit 0. Written with
+  # numbers valid in a 32-bit signed integer and 64-bit signed
+  # integer arithmetic.
+  # All bits 1 outside the netmask is the broadcast address
+  # of the subnet.
+  echo $(( ($1 & $2) | ((65535<<16|65534) & ~$2) ))
 }
 
 
@@ -806,12 +809,11 @@ orc_pingIP4localnet() {
   fi
   myaddr=$(orc_IP4toInteger "$1")
   mask=$(orc_IP4toInteger "$2")
-  value=$(orc_firstIp4integer "$myaddr" "$mask")
+  value=$(orc_firstIP4integer "$myaddr" "$mask")
   lastvalue=$(orc_lastIP4integer "$myaddr" "$mask")
-  while [ 1 ]; do
+  while true; do
     address=$(orc_integerToIP4 "$value")
-    if ping -c1 -n "$address" > /dev/null
-    then
+    if ping -c1 -n "$address" > /dev/null; then
       echo "$address is alive"
     fi
     if [ "$value" -eq "$lastvalue" ]; then


### PR DESCRIPTION
- orc_lastIP4Integer was broken in shells with 64-bit integers, was working with 32-bit integers only. The bug should be fixed.
- Some shellcheck findings are removed. The code should be more portable to other shell interpreters now.
- Add static code check with the shellcheck tool for the shell scripts in the resources sub-directory.
