### PR TITLE
getgtfobins optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: minimal
 
 # All available Linux distributions with language minimal:
+#   Ubuntu 18.04 (Bionic Beaver) 
 #   Ubuntu Xenial 16.04
 #   Ubuntu Trusty 14.04
-# Ubuntu Precise 12.04 is not supported.
+# Ubuntu Precise 12.04 has reached EOL and is not supported by Travis.
 matrix:
   include:
     - os: linux
       dist: trusty
     - os: linux
-      dist: xenial
+      dist: xenial#
+    - os: linux
+      dist: bionic
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - os: linux
       dist: trusty
     - os: linux
-      dist: xenial#
+      dist: xenial
     - os: linux
       dist: bionic
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ HOWEVER. An overview:
 
 - getexploit pulls down the linux exploit suggester ([Wiki](https://github.com/zMarch/Orc/wiki/getexploit))
 
+- getgtfobins pulls down the list of current gtfobins and checks to see which are installed in your $PATH ([Wiki](https://github.com/zMarch/Orc/wiki/getgtfobins))
+
 - getsctp checks if SCTP support is enabled. ([Wiki](https://github.com/zMarch/Orc/wiki/getsctp))
 
 - getidle gives you an accurate idle time for ptys, letting you see how recently other users have been active. ([Wiki](https://github.com/zMarch/Orc/wiki/getidle))
@@ -70,8 +72,6 @@ HOWEVER. An overview:
 - getusers gets all users with a shell. ([Wiki](https://github.com/zMarch/Orc/wiki/getusers))
 
 - getuservices gets all processes running by users who don't have a shell. Useful. ([Wiki](https://github.com/zMarch/Orc/wiki/getuservices))
-
-- getgtfobins pulls down the list of current gtfobins and checks to see which are installed in your $PATH
 
 - memexec uses some janky perl (see https://magisterquis.github.io/2018/03/31/in-memory-only-elf-execution.html who I stole much of the basis of it for) to execute a binary in-memory. No arguments or anything yet, and only x64 supported. ([Wiki](https://github.com/zMarch/Orc/wiki/memexec))
 

--- a/o.rc
+++ b/o.rc
@@ -1368,24 +1368,44 @@ getip() {
 getgtfobins() {
   # Pulls down the list of current gtfobins and checks to see
   # which are installed in your $PATH
-  orc_local cmd_name n_found n_notfound n_total
-  n_notfound=0
-  n_found=0
-  n_total=0
+  # The HTML source of the GTFOBins page is generated. So the structure of the
+  # file is very constant. Here a simple regex pattern is implemented to grep
+  # the program names.
   orc_loadURL 'https://gtfobins.github.io/' |
-  grep $orc_colorNever 'gtfobins/' |
-  grep $orc_colorNever 'td\>' |
-  awk -F '/' '{print $3}' | (
+  awk '/<a href="\/gtfobins\/([^\/]*)\/" class="bin-name">/ {split($0,a,"/"); print a[3]}' |
+  (
+    orc_local cmd_name find_args find_result
+    orc_local n_total n_direct n_outside n_notfound
+    n_total=0
+    n_direct=0
+    n_outside=0
+    n_notfound=0
     while read -r cmd_name; do
       n_total=$(( n_total + 1 ))
       if orc_existsProg "$cmd_name"; then
         echo "$cmd_name"
-        n_found=$(( n_found + 1 ))
+        n_direct=$(( n_direct + 1 ))
       else
         n_notfound=$(( n_notfound + 1 ))
+        if [ "$n_notfound" -eq 1 ]; then
+          find_args="( -name $cmd_name"
+        else
+          find_args="$find_args -or -name $cmd_name"
+        fi
       fi
     done
-    echo "GTFOBins: $n_found of $n_total commands found, $n_notfound not found"
+    if [ "$n_notfound" -gt 0 ] && orc_existsProg find; then
+      find_args="$find_args )"
+      # The find_args are not quoted because it must be splitted.
+      # Counting with a pipe into a while read loop is complicated.
+      # shellcheck disable=SC2044,SC2086
+      for find_result in $(find / -executable -type f $find_args 2> /dev/null); do
+        echo "$find_result"
+        n_outside=$(( n_outside + 1 ))
+      done
+    fi
+    echo "GTFOBins: $n_total commands in web page"
+    echo "GTFOBins: found $n_direct in PATH and $n_outside outside PATH"
   )
 }
 
@@ -1440,7 +1460,7 @@ getrel() {
   # arguments: none
   # output   : print to stdout
   # method   : Cuts the name from lines like PRETTY_NAME="name".
-  awk -F= 'toupper($1)~/PRETTY/ {gsub(/\"/,"",$2); print $2}' /etc/*release
+  awk -F= 'toupper($1)~/PRETTY/ {gsub(/"/,"",$2); print $2}' /etc/*release
 }
 
 hangup() {

--- a/o.rc
+++ b/o.rc
@@ -1349,24 +1349,46 @@ fpssh() {
 }
 
 getip() {
-#we use akamai and google here because they're gonna look less dodgy in SOC's logs
-echo 'Attempting to get IP...'
-printf 'HTTP says: '
-	orc_loadURL 'https://whatismyip.akamai.com'
-echo ''
-printf 'DNS says: '
-	if orc_existsProg dig; then
-	dig +time=3 +tries=1 TXT +short o-o.myaddr.l.google.com @ns1.google.com | tr -d \"
-	echo '(used dig)'
-	else
-	host -W 3 -t txt o-o.myaddr.l.google.com ns1.google.com | grep $orc_colorNever descriptive | awk -F ' ' '{print $4}' | tr -d '"' | tr -d "\n"
-	echo '(used host)'
-	fi
+  #we use akamai and google here because they're gonna look less dodgy in SOC's logs
+  echo 'Attempting to get IP...'
+  printf 'HTTP says: '
+  orc_loadURL 'https://whatismyip.akamai.com'
+  echo ''
+  printf 'DNS says: '
+  if orc_existsProg dig; then
+    dig +time=3 +tries=1 TXT +short o-o.myaddr.l.google.com @ns1.google.com | tr -d \"
+    echo '(used dig)'
+  else
+    host -W 3 -t txt o-o.myaddr.l.google.com ns1.google.com | grep $orc_colorNever descriptive | awk -F ' ' '{print $4}' | tr -d '"' | tr -d "\n"
+    echo '(used host)'
+  fi
 }
 
+
 getgtfobins() {
-type $(orc_loadURL 'https://gtfobins.github.io/' | grep --color=never "gtfobins/" | grep "td\>" | awk -F "/" '{print $3}' | tr '\n' ' ')
+  # Pulls down the list of current gtfobins and checks to see
+  # which are installed in your $PATH
+  orc_local cmd_name n_found n_notfound n_total
+  n_notfound=0
+  n_found=0
+  n_total=0
+  orc_loadURL 'https://gtfobins.github.io/' |
+  grep $orc_colorNever 'gtfobins/' |
+  grep $orc_colorNever 'td\>' |
+  awk -F '/' '{print $3}' | (
+    while read -r cmd_name; do
+      n_total=$(( n_total + 1 ))
+      if orc_existsProg "$cmd_name"; then
+        echo "$cmd_name"
+        n_found=$(( n_found + 1 ))
+      else
+        n_notfound=$(( n_notfound + 1 ))
+      fi
+    done
+    echo "GTFOBins: $n_found of $n_total commands found, $n_notfound not found"
+  )
 }
+
 
 prochide() {
   # Execute a program hidden by a long program name.
@@ -1391,10 +1413,10 @@ getnet() {
   orc_collectOtherHostsInfo
   echo "Pinging local IPv4 address in background writing $HOME/ips ..."
   orc_inetAddressAndMask |
-   while read -r addr mask; do
-     echo "Pinging subnet around $addr with mask $mask"
-     ( orc_pingIP4localnet "$addr" "$mask"  >> $HOME/ips )&
-   done
+       while read -r addr mask; do
+         echo "Pinging subnet around $addr with mask $mask"
+         ( orc_pingIP4localnet "$addr" "$mask"  >> $HOME/ips )&
+       done
 }
 
 
@@ -1583,8 +1605,9 @@ A probably non-comprehensive list of functionality in Orc v$OVERSION.
 [*]      getenum - get kernel, glibc, and dbus versions
 [*]    getescape - attempt to escape chroot via bad privs
 [*]                on the /proc/ filesystem
-[*]	getsctp - check if the box has support for SCTP
+[*]	     getsctp - check if the box has support for SCTP
 [*]   getexploit - download and run linux-exploit-suggester
+[*]  getgtfobins - pull a list of the current gtfobins and find which are on the system
 [*]      getidle - list all ptys and their idle times accurately.
 [*]      getinfo - create a tar.xz of useful command output
 [*]        getip - get external IP from akamai and google (HTTP and DNS)
@@ -1615,7 +1638,6 @@ A probably non-comprehensive list of functionality in Orc v$OVERSION.
 [*]        stomp - alias for touch -r (needs arguments)
 [*]        tools - check for common tools
 [*]        wiper - remove entries from wtmp - wiper [string to grep out]
-[*]	   getgtfobins - pull a list of the current gtfobins and find which are on the system
 "
 }
 

--- a/tests/run_shunit2_user.sh
+++ b/tests/run_shunit2_user.sh
@@ -35,6 +35,19 @@ test_gethelp() {
 }
 
 
+test_getgtfobins() {
+  # Test the getgtfobins function
+  output=$(getgtfobins 2> /dev/null)
+  assertEquals 'returned false' 0 $?
+  assertNotNull 'output is null' "$output"
+  assertContains 'in output' "$output" 'GTFOBins:'
+  assertTrue 'less than 5 lines' "[ $(echo "$output"|wc -l) -ge 5 ]"
+  error=$(getgtfobins 2>&1 > /dev/null)
+  assertNull 'error message' "$error"
+  if [ -n "$error" ]; then echo "--> $error"; fi
+}
+
+
 test_getsfiles() {
   # Test the getsfiles function
   error=$(getsfiles background 2>&1 > /dev/null)

--- a/tests/start_shunit2.sh
+++ b/tests/start_shunit2.sh
@@ -31,7 +31,8 @@ export SHUNIT_COLOR
 SHUNIT_COLOR='always'
 
 # Run the tests
-for runner in $(readlink -e ./tests/run_shunit2_*.sh); do
+for runner in ./tests/run_shunit2_*.sh; do
+  runner="$(readlink -e "$runner")"
   echo ">>> start script '$runner'"
   case $1 in
     bash)  bash -i "$runner" ;;


### PR DESCRIPTION
Optimization of the getgtfobins command is in process:

- [X] Add a Wiki page
- [X] list only the existing programs, print only the number of not found programs
- [X] search the files also outside the current $PATH. (The $PATH directories of the current user could give a strong reduced view to the system.)
- [X] add getgtfobins to the tests
- [X] reduce the call chain grep, grep, awk, tr to a single awk call
- [X] fix shellcheck finding

Besides the Ubuntu 18.04 LTS is added to the automated tests via Travis.